### PR TITLE
Output directly to CSV from sq-ldm-240

### DIFF
--- a/bin/sq-ldm-240
+++ b/bin/sq-ldm-240
@@ -4,9 +4,11 @@ from __future__ import print_function
 
 # standard dependencies
 import os
+import csv
 import sys
 import argparse
 import textwrap
+from collections import OrderedDict
 
 # PyPI dependencies
 from jira import JIRA   # jira API python module
@@ -51,6 +53,11 @@ parser.add_argument('-t', '--title',
                     default=False,
                     help='Show the JIRA issue title in the table cell (can combine with -k)')
 
+parser.add_argument('-c', '--csv',
+                    action='store_true',
+                    default=False,
+                    help='Output as CSV format')
+
 parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.5')
 
 opt = parser.parse_args()
@@ -73,45 +80,48 @@ project = jira.project('DLP')
 cycles = jirakit.cycles()
 if debug: print(cycles)
 
-milestones = jira.search_issues('project = DLP and issuetype = Milestone order by WBS ASC',
+def makeRow(wbs, cycles, blank=None):
+    row = OrderedDict()
+    row['WBS'] = wbs
+    for cycle in cycles:
+        row[cycle] = blank
+    return row
+
+milestones = jira.search_issues('project = DLP and issuetype = Milestone order by WBS, id ASC',
                                 maxResults=1000)
 
-table = [cycles]
-
+table = []
 for milestone in milestones:
     issue = jira.issue(milestone)
     #    if debug: print(milestone)
 
     # Get the release associated with this milestone
-    if issue.fields.fixVersions:
-        release = issue.fields.fixVersions[0]
-        cyc = release.name
-        milestonestr = milestone.key
-        if issue.fields.customfield_10500:
-            WBS = issue.fields.customfield_10500
-        else:
-            WBS = 'None'
-
-        row = [WBS]
-
-        for k in cycles:
-            if k == cyc:
-
-                if opt.title and opt.key:
-                    cell = milestonestr + ': ' + milestone.fields.summary
-                elif opt.title:
-                    cell = milestone.fields.summary
-                else:
-                    cell = milestonestr
-
-                # row.append(milestonestr)
-                row.append(cell)
-            else:
-                row.append("-")
-        table.append(row)
-    else:
+    if not issue.fields.fixVersions:
         print('No release assigned to', issue.key, file=sys.stderr)
+        continue
 
-cycles.insert(0, 'WBS')
+    cyc = issue.fields.fixVersions[0].name
+    milestonestr = milestone.key
 
-print(tabulate.tabulate(table, headers="firstrow",tablefmt='pipe'))
+    if issue.fields.customfield_10500:
+        WBS = issue.fields.customfield_10500
+    else:
+        WBS = 'None'
+
+    row = makeRow(WBS, cycles, "" if opt.csv else "-")
+
+    if opt.title and opt.key:
+        row[cyc] = milestone.key + ': ' + milestone.fields.summary
+    elif opt.title:
+        row[cyc] = milestone.fields.summary
+    else:
+        row[cyc] = milestone.key
+
+    table.append(row)
+
+if opt.csv:
+    writer = csv.DictWriter(sys.stdout, fieldnames=table[0].keys())
+    writer.writeheader()
+    writer.writerows(table)
+else:
+    print(tabulate.tabulate(table, headers='keys', tablefmt='pipe'))

--- a/bin/sq-ldm-240
+++ b/bin/sq-ldm-240
@@ -76,8 +76,6 @@ if debug: print(cycles)
 milestones = jira.search_issues('project = DLP and issuetype = Milestone order by WBS ASC',
                                 maxResults=1000)
 
-cycles.insert(0, 'WBS')
-
 table = [cycles]
 
 for milestone in milestones:
@@ -114,5 +112,6 @@ for milestone in milestones:
     else:
         print('No release assigned to', issue.key, file=sys.stderr)
 
+cycles.insert(0, 'WBS')
 
 print(tabulate.tabulate(table, headers="firstrow",tablefmt='pipe'))

--- a/lsst/sqre/jirakit.py
+++ b/lsst/sqre/jirakit.py
@@ -3,15 +3,7 @@
 Module for helper apps relating to the LSST-DM reporting cycle
 """
 
-def cycles():
-    cyclelist = []
-    seasons = ['W','S']
-    # years 15-20
-    years = range(15,21)
-    index = 0
-    for yy in years:
-        for s in seasons:
-            cyclelist.append(s + str(yy))
-            index += 1
+import itertools
 
-    return cyclelist
+def cycles(seasons=['W', 'S'], years=range(15,21)):
+    return ["%s%d" % (s, y) for y in years for s in seasons]


### PR DESCRIPTION
Adds a command line flag to dump CSV to stdout rather than having to postprocess.

Also fixes a minor layout bug (observe the WBS column at https://github.com/lsst-dm/dmlt-docs/blob/master/ldm-240.csv).
