### PR TITLE
Add "sanity checking" script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ in to the URL. Note that `*` acts as a wildcard. For example, try:
 - [http://127.0.0.1:8080/wbs/02C.04.04](http://127.0.0.1:8080/wbs/02C.04.04)
 - [http://127.0.0.1:8080/wbs/02C.04.*](http://127.0.0.1:8080/wbs/02C.04.*)
 
+dlp-sanity
+----------
+
+Checks the DLP JIRA project for consistency. At present, this means it
+identifies any "bad" blocking relationships, where a blocked Milestone is
+scheduled to take place in an earlier cycle than the Milestone or Meta-epics
+which are blocking it. This is smart enough to follow chains of blocks (ie, if
+A blocks B and B blocks C, A is regarded as blocking C), but the current
+implementation does not report intermediate issues (thus the above
+relationship is simply reported as "A blocks C"); use e.g. dlp-graph (above)
+to identify these where necessary.
+
+No options necessary simply run `dlp-sanity`. Returns 0 if no problems are
+detected; prints a list of bad blocks and exits with status 1 otherwise.
+
 Known Bugs etc
 ==============
 

--- a/bin/dlp-sanity
+++ b/bin/dlp-sanity
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import sys
+
+from lsst.sqre.jirakit import SERVER, cycles
+from jira import JIRA
+
+QUERY = 'project = DLP AND issuetype in (Milestone, "Meta-epic")'
+MAX_RESULTS = 1000
+
+def compare(a, b, ordering=cycles()):
+    # Returns negative if a appears before b in ordering, zero if a
+    # and b are at the same position, positive if a is after b.
+    return cmp(ordering.index(a), ordering.index(b))
+
+def get_issues(query, jiraConn):
+    # Construct a mapping from Id to milestone for all milestones
+    # which satisfy QUERY.
+    return {issue.key: issue for issue in jiraConn.search_issues(query, maxResults=MAX_RESULTS)}
+
+def get_cycle(issue):
+    # Return the name of the first entry in the fixVersions field of issue.
+    return issue.fields.fixVersions[0].name
+
+def good_block(blocker, blocked, compare_fn=compare):
+    # Return True for a well ordered block, False for reversed
+    return True if compare_fn(get_cycle(blocker), get_cycle(blocked)) <= 0 else False
+
+def get_dependents(key, issues, visited=None):
+    # Return the set of keys of all milestones which are blocked by the given key. We use
+    # visited to avoid getting stuck in cycles in the graph; note that we don't report such
+    # cycles explicitly, but they should usually be apparent from the bad blocks report.
+    dependents = set()
+    if not visited:
+        visited = []
+    if key not in visited:
+        visited.append(key)
+        for link in issues[key].fields.issuelinks:
+            if (link.type.name == "Blocks" and hasattr(link, "outwardIssue")
+                and link.outwardIssue.key in issues):
+                if link.outwardIssue.fields.issuetype.name == "Milestone":
+                    dependents.add(link.outwardIssue.key)
+                dependents = dependents.union(get_dependents(link.outwardIssue.key, issues, visited))
+    return dependents
+
+def get_bad_blocks(issues, compare_fn=compare):
+    # Return a list of (blocker_key, blocked_key) tuples for all bad blocks in
+    # the set of issues, where a "bad block" is defined as the blocked issue
+    # being scheduled for a cycle earlier than its blocker.
+    return [(blocker_key, blocked_key)
+            for blocker_key, blocker in issues.iteritems()
+            for blocked_key in get_dependents(blocker_key, issues)
+            if blocker.fields.issuetype.name == "Milestone"
+            and not good_block(blocker, issues[blocked_key], compare_fn)]
+
+if __name__ == "__main__":
+    issues = get_issues(QUERY, JIRA(dict(server=SERVER)))
+    bad_blocks = get_bad_blocks(issues)
+    if bad_blocks:
+        for blocker, blocked in bad_blocks:
+            print("%s (%s) blocks %s (%s)" % (blocker, get_cycle(issues[blocker]),
+                                              blocked, get_cycle(issues[blocked])))
+        sys.exit(1)


### PR DESCRIPTION
This identifies badly-ordered blocking relationships in the DLP project.
