### PR TITLE
Check for unscheduled milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,18 @@ dlp-sanity
 ----------
 
 Checks the DLP JIRA project for consistency. At present, this means it
-identifies any "bad" blocking relationships, where a blocked Milestone is
-scheduled to take place in an earlier cycle than the Milestone or Meta-epics
-which are blocking it. This is smart enough to follow chains of blocks (ie, if
-A blocks B and B blocks C, A is regarded as blocking C), but the current
-implementation does not report intermediate issues (thus the above
-relationship is simply reported as "A blocks C"); use e.g. dlp-graph (above)
-to identify these where necessary.
+identifies:
+
+* Milestones which are not scheduled for a particular release ("fixVersion");
+* "Bad" blocking relationships.
+
+Bad blocks are those in which a blocked Milestone is scheduled to take place
+in an earlier cycle than the Milestone or Meta-epics which are blocking it.
+This is smart enough to follow chains of blocks (ie, if A blocks B and B
+blocks C, A is regarded as blocking C), but the current implementation does
+not report intermediate issues (thus the above relationship is simply reported
+as "A blocks C"); use e.g. dlp-graph (above) to identify these where
+necessary.
 
 No options necessary simply run `dlp-sanity`. Returns 0 if no problems are
 detected; prints a list of bad blocks and exits with status 1 otherwise.

--- a/bin/dlp-sanity
+++ b/bin/dlp-sanity
@@ -54,12 +54,31 @@ def get_bad_blocks(issues, compare_fn=compare):
             if blocker.fields.issuetype.name == "Milestone"
             and not good_block(blocker, issues[blocked_key], compare_fn)]
 
+def get_unscheduled_milestones(issues):
+    # Return a list of keys of all Milestones which do not have a fixVersion defined.
+    return [key for key, issue in issues.iteritems()
+            if issue.fields.issuetype.name == "Milestone"
+            and (not hasattr(issue.fields, "fixVersions")
+                 or not issue.fields.fixVersions)]
+
 if __name__ == "__main__":
     issues = get_issues(build_query(("Milestone", "Meta-epic"), "02C*"),
                         JIRA(dict(server=SERVER)))
+    found_errors = False
+
+    # Check for unscheduled milestones
+    unscheduled = get_unscheduled_milestones(issues)
+    for key in unscheduled:
+        found_errors=True
+        del issues[key] # Trim the issue so it doesn't break the bad blocks check
+        print("%s is not scheduled in any cycle." % (key,))
+
+    # Check for bad blocks
     bad_blocks = get_bad_blocks(issues)
-    if bad_blocks:
-        for blocker, blocked in bad_blocks:
-            print("%s (%s) blocks %s (%s)" % (blocker, get_cycle(issues[blocker]),
-                                              blocked, get_cycle(issues[blocked])))
+    for blocker, blocked in bad_blocks:
+        found_errors = True
+        print("%s (%s) blocks %s (%s)." % (blocker, get_cycle(issues[blocker]),
+                                          blocked, get_cycle(issues[blocked])))
+
+    if found_errors:
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email="dm-devel@lists.lsst.org",
     url="https://github.com/lsst-sqre/sqre-jirakit",
     packages=['lsst', 'lsst.sqre'],
-    scripts=['bin/sq-ldm-240', 'bin/dlp-graph', 'bin/dlp-web'],
+    scripts=['bin/sq-ldm-240', 'bin/dlp-graph', 'bin/dlp-web', 'bin/dlp-sanity'],
     install_requires=['jira', 'tabulate', 'flask', 'graphviz'],
     test_suite="tests",
 )


### PR DESCRIPTION
Identifying them is probably useful in itself, but also they cause the bad-blocks check in `dlp-sanity` to fail.
