### PR TITLE
Fixing broken test and PEP8 warnings.

### DIFF
--- a/tests/test_jirakit.py
+++ b/tests/test_jirakit.py
@@ -14,9 +14,7 @@ class JiraKitTest(unittest.TestCase):
     def testCycle(self):
 
         c = jirakit.cycles()
-        self.assertEqual(c[0],'W15')
+        self.assertEqual(c.next(), 'S14')
 
 if __name__ == '__main__':
     unittest.main()
-
-    


### PR DESCRIPTION
Change to cycles function broke the test. Oops!
