### PR TITLE
Adding OpSim workplanning scripts and helpers and PEP8 fixes for jirakit.py

### DIFF
--- a/bin/opsim-combwp
+++ b/bin/opsim-combwp
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+# standard dependencies
+import argparse
+import textwrap
+
+# in-house modules
+import lsst.sqre.jirakit
+
+from lsst.sqre.jira2confluence import create_list_from_numbered_description
+from lsst.sqre.confluence import bold
+from lsst.sqre.confluence import heading
+from lsst.sqre.confluence import table
+
+# argument parsing and default options
+
+parser = argparse.ArgumentParser(
+    prog='opsim-combwp',
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=textwrap.dedent('''
+
+    Generate a side-by-side listing of the SOCS / Scheduler combined workplan in Confluence format.
+
+    The output can be piped into a file that can then be cut-and-pasted into a Confluence page via the
+    Markdown menu option.
+
+    '''),
+    epilog='Part of jirakit: https://github.com/lsst-sqre/sqre-jirakit'
+)
+
+parser.add_argument('-s', '--server',
+                    default=lsst.sqre.jirakit.SERVER,
+                    help='JIRA server URL')
+parser.add_argument('-a', '--auth-file',
+                    default=None,
+                    help='Path to a file containing basic authentication information')
+parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.1')
+
+if __name__ == "__main__":
+
+    opt = parser.parse_args()
+
+    from jira import JIRA
+    jira_server = JIRA(server=opt.server, basic_auth=lsst.sqre.jirakit.basic_auth_from_file(opt.auth_file))
+
+    query = "project = Simulations AND issuetype = Epic AND summary ~ \"SOCS Release\" ORDER BY key"
+    issues = jira_server.search_issues(query)
+
+    page_content = []
+    import time
+    page_content.append("This page provides the coordinated work plan between the Simulated OCS (SOCS) "
+                        "and the Scheduler.")
+    page_content.append("Updated: {0}".format(time.strftime("%Y-%m-%d %H:%M", time.localtime())))
+    page_content.append("")
+
+    import os
+    for issue in issues:
+        socs_summary = issue.fields.summary
+        version = socs_summary.split()[-1]
+        page_content.append(heading("Combined Release {0}".format(version), 2))
+
+        socs_descr = issue.fields.description
+        comb_duedate = issue.fields.duedate
+        page_content.append("{0} {1}".format(bold("Release Date:"), comb_duedate))
+        page_content.append("")
+
+        socs_work = create_list_from_numbered_description(socs_descr)
+
+        # Should only be one!
+        sched_epic = jira_server.issue(lsst.sqre.jirakit.get_issue_links(issue,
+                                                                         "Relates")[0].outwardIssue.key)
+        sched_summary = sched_epic.fields.summary
+        sched_descr = sched_epic.fields.description
+
+        sched_work = create_list_from_numbered_description(sched_descr)
+
+        # Create Table
+        headings = ["{0} Workplan".format(socs_summary.split()[0]),
+                    "{0} Workplan".format(sched_summary.split()[0])]
+
+        page_content.append(table(headings, socs_work, sched_work, onerow=True))
+
+        page_content.append("")
+        page_content.append("")
+
+    print(os.linesep.join(page_content))

--- a/bin/socs-workplan
+++ b/bin/socs-workplan
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+# standard dependencies
+import argparse
+import textwrap
+
+# in-house modules
+import lsst.sqre.jirakit
+
+from lsst.sqre.jira2confluence import check_description
+from lsst.sqre.jira2confluence import create_list_from_numbered_description
+from lsst.sqre.confluence import bold
+from lsst.sqre.confluence import heading
+from lsst.sqre.confluence import table
+
+# argument parsing and default options
+
+parser = argparse.ArgumentParser(
+    prog='socs-workplan',
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=textwrap.dedent('''
+
+    Generate a full listing of the SOCS workplan possibly including issues in Confluence format.
+
+    The output can be piped into a file that can then be cut-and-pasted into a Confluence page via the
+    Markdown menu option.
+
+    '''),
+    epilog='Part of jirakit: https://github.com/lsst-sqre/sqre-jirakit'
+)
+
+parser.add_argument('-s', '--server',
+                    default=lsst.sqre.jirakit.SERVER,
+                    help='JIRA server URL')
+parser.add_argument('-a', '--auth-file',
+                    default=None,
+                    help='Path to a file containing basic authentication information')
+parser.add_argument('-i', '--issues', action="store_true",
+                    default=False,
+                    help='Flag for adding table of issues assigned to epics')
+parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.1')
+
+if __name__ == "__main__":
+
+    opt = parser.parse_args()
+
+    from jira import JIRA
+    jira_server = JIRA(server=opt.server, basic_auth=lsst.sqre.jirakit.basic_auth_from_file(opt.auth_file))
+
+    query = "project = Simulations AND issuetype = Epic AND summary ~ \"SOCS Release\" ORDER BY key"
+    issues = jira_server.search_issues(query)
+
+    page_content = []
+    import time
+    page_content.append("This page details the SOCS workplan.")
+    page_content.append("Updated: {0}".format(time.strftime("%Y-%m-%d %H:%M", time.localtime())))
+    page_content.append("")
+
+    import os
+    for issue in issues:
+        socs_summary = issue.fields.summary
+        page_content.append(heading(socs_summary, 2))
+        socs_duedate = issue.fields.duedate
+        page_content.append("{0} {1}".format(bold("Release Date:"), socs_duedate))
+        page_content.append("")
+
+        page_content.append(heading("Statement of Work", 3))
+        socs_descr = issue.fields.description
+        socs_work = create_list_from_numbered_description(socs_descr)
+        page_content.append(os.linesep.join(socs_work))
+        page_content.append("")
+
+        sub_epic_links = lsst.sqre.jirakit.get_issue_links(issue, "Containment")
+        sub_epics = [jira_server.issue(sub_epic_link.outwardIssue.key) for sub_epic_link in sub_epic_links]
+        for sub_epic in sub_epics:
+            page_content.append(heading(sub_epic.fields.summary, 4))
+            page_content.append(heading("Statement of Work", 5))
+            page_content.append(check_description(sub_epic.fields.description))
+            page_content.append("")
+            if opt.issues:
+                page_content.append(heading("Issues", 6))
+                se_issues = jira_server.search_issues("'Epic Link' = '{0}'".format(sub_epic.fields.summary))
+                page_content.append("Number of Issues = {0}".format(len(se_issues)))
+                page_content.append("")
+                if len(se_issues) > 0:
+                    headers = ["Key", "Description", "Status"]
+                    keys = [se_issue.key for se_issue in se_issues]
+                    summaries = [se_issue.fields.summary for se_issue in se_issues]
+                    status_names = [se_issue.fields.status.name for se_issue in se_issues]
+                    page_content.append(table(headers, keys, summaries, status_names))
+                    page_content.append("")
+
+    print(os.linesep.join(page_content))

--- a/lsst/sqre/confluence.py
+++ b/lsst/sqre/confluence.py
@@ -1,0 +1,56 @@
+"""
+Module for Confluence text processing.
+"""
+
+def bold(text):
+    """Make Confluence bold text.
+    """
+    return "*{0}*".format(text)
+
+def heading(title, level=1):
+    """Make a Confluence heading level.
+    """
+    return "h{0}. {1}".format(level, title)
+
+def table(headings, *columns, **kwargs):
+    """Make a Confluence table.
+
+    This function creates a Confluence table.
+
+    Args:
+        headings: An iterable of strings representing the column headings for the table.
+        columns: A set of iterables (usually strings) containing the corresponding columns
+            for the table.
+        **kwargs:
+            onerow: A boolean flag to make each column information iterable into a single row.
+
+    Returns:
+        A string containing the table formatting and information.
+    """
+    import itertools
+    import os
+    table = []
+
+    onerow = kwargs.get("onerow", False)
+
+    header = ["||"]
+    for heading in headings:
+        header.append(heading)
+        header.append("||")
+    table.append(" ".join(header))
+
+    if onerow:
+        row = ["|"]
+        for column in columns:
+            row.append(os.linesep.join(column))
+            row.append("|")
+        table.append(" ".join(row))
+    else:
+        for colvals in itertools.izip_longest(*columns, fillvalue=" "):
+            row = ["|"]
+            for colval in colvals:
+                row.append(colval)
+                row.append("|")
+            table.append(" ".join(row))
+
+    return os.linesep.join(table)

--- a/lsst/sqre/jira2confluence.py
+++ b/lsst/sqre/jira2confluence.py
@@ -1,0 +1,26 @@
+"""
+Module for Confluence helper functions.
+"""
+
+def check_description(descr):
+    """Check a JIRA description field.
+    """
+    if descr is None:
+        return "No description provided."
+    else:
+        return descr
+
+def create_list_from_numbered_description(desrc, bulletType="*"):
+    """Create Confluence list from a JIRA numbered description.
+    """
+    import os
+    olist = []
+    for line in desrc.strip().split(os.linesep):
+        values = line.split()
+        listnum = values[0].split('.')
+        lenlist = len(listnum)
+        if listnum[-1] == '':
+            lenlist -= 1
+        numbered = bulletType * lenlist
+        olist.append("{0} {1}".format(numbered, " ".join(values[1:])))
+    return olist

--- a/lsst/sqre/jirakit.py
+++ b/lsst/sqre/jirakit.py
@@ -1,15 +1,36 @@
 
 """
-Module for helper apps relating to the LSST-DM reporting cycle
+Module for helper apps relating to the LSST-DM reporting cycle and LSST-SIMS work planning.
 """
 
-import itertools
+SERVER = "https://jira.lsstcorp.org/"
 
-SERVER="https://jira.lsstcorp.org/"
-
-def cycles(seasons=['W', 'S'], years=range(14,22)):
+def cycles(seasons=['W', 'S'], years=range(14, 22)):
     # S14 is a cycle but W14 is not
     return ("%s%d" % (s, y) for y in years for s in seasons if not (s == 'W' and y == 14))
 
 def build_query(issue_types, wbs):
-    return 'project = DLP AND issuetype in (%s) AND wbs ~ "%s" ORDER BY wbs ASC, fixVersion DESC' % (", ".join(issue_types), wbs)
+    return 'project = DLP AND issuetype in (%s) AND wbs ~ "%s" ORDER BY wbs ASC, fixVersion DESC' % \
+        (", ".join(issue_types), wbs)
+
+def basic_auth_from_file(auth_file_path=None):
+    """Get basic auth from a two line file.
+    """
+    if auth_file_path is None:
+        import os
+        auth_file_path = os.path.join(os.path.expanduser("~/"), ".jira_auth")
+
+    with open(auth_file_path, 'r') as fd:
+        uname = fd.readline().strip()  # Can't hurt to be paranoid
+        pwd = fd.readline().strip()
+
+    return (uname, pwd)
+
+def get_issue_links(issue, linkTypeName=None):
+    """Get links from an issue.
+    """
+    links = issue.fields.issuelinks
+    if linkTypeName is None:
+        return links
+    else:
+        return [link for link in links if link.type.name in linkTypeName]

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, absolute_import, division
+
+import unittest
+
+import lsst.sqre.confluence as confluence
+
+class ConfluenceTest(unittest.TestCase):
+
+    def testBold(self):
+        istr = "test"
+        self.assertEqual(confluence.bold(istr), "*test*")
+
+    def testHeading(self):
+        self.assertEqual(confluence.heading("title"), "h1. title")
+        self.assertEqual(confluence.heading("title", 4), "h4. title")
+
+    def testTable(self):
+        import os
+        table = []
+        table.append("|| A || B ||")
+        table.append("| a | d |")
+        table.append("| b | e |")
+        table.append("| c |   |")
+
+        headings = ["A", "B"]
+        col1 = ["a", "b", "c"]
+        col2 = ["d", "e"]
+        self.assertEqual(confluence.table(headings, col1, col2), os.linesep.join(table))
+
+        table2 = []
+        table2.append("|| A || B ||")
+        table2.append("| a\nb\nc | d\ne |")
+        self.assertEqual(confluence.table(headings, col1, col2, onerow=True), os.linesep.join(table2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
As our simplified JIRA work planning didn't quite fit within the established DLP methodology, I couldn't figure a good way to tear things apart to make them useable without a good deal of work and the extreme risk of breaking things that work for DLP. Also, our output products are primitive in nature for now. So, I've laid our additions alongside, but did not add them into the installation script to avoid pollution. 
